### PR TITLE
#174487991: Upgrade commander, because of dependency conflict with other plugin

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -3,7 +3,7 @@
 # version: 0.0.1
 # authors: Kyle Welsby <kyle@mekyle.com>
 
-gem 'commander', '4.4.3' # , require: false # for analytics-ruby
+gem 'commander', '4.5.2' # , require: false # for analytics-ruby
 gem 'analytics-ruby', '2.2.2', require: false # 'segment/analytics'
 
 enabled_site_setting :segment_io_enabled


### PR DESCRIPTION
When we install a new plugin in Discourse, *all* the plugins get upgraded. 

While attempting to install a new plugin in stage (in preparation for installing it in production Thursday), there was a new dependency resolution issue for the `highline` package, which is a dependency of `commander` (with one of the old plugins, not the new one, though it's not clear to me which one). I've upgraded the `commander` package here (which uses a newer version of `highline`) in order to resolve that issue.

Related to https://www.pivotaltracker.com/story/show/174487991