### PR TITLE
#175034101: Remove dq_user_id from most events

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -92,8 +92,7 @@ after_initialize do
           name: "#{controller_name}##{action_name}",
           properties: {
             url: request.original_url,
-            user_email: current_user.email,
-            dq_user_id: current_user.single_sign_on_record.external_id
+            user_email: current_user.email
           },
           context: {
             ip: request.ip,
@@ -124,8 +123,7 @@ after_initialize do
           created_at: created_at,
           since_topic_created: (created_at - topic.created_at).to_i,
           reply_to_post_number: reply_to_post_number,
-          user_email: user.email,
-          dq_user_id: user.single_sign_on_record.external_id
+          user_email: user.email
         }
       )
     end
@@ -143,8 +141,7 @@ after_initialize do
           slug: slug,
           title: title,
           url: url,
-          user_email: user.email,
-          dq_user_id: user.single_sign_on_record.external_id
+          user_email: user.email
         }
       )
     end
@@ -178,8 +175,7 @@ after_initialize do
           post_id: target_post_id,
           topic_id: target_topic_id,
           like_count: target_topic.like_count,
-          user_email: user.email,
-          dq_user_id: user.single_sign_on_record.external_id
+          user_email: user.email
         }
       )
     end


### PR DESCRIPTION
There are ~15k errors in [the logs](https://community.dataquest.io/logs/) like `Job exception: undefined method 'external_id' for nil:NilClass` from trying to access `user.single_sign_on_record.external_id`. These are correlated to user reports of 500 errors when trying to create posts. It's not clear whether all 15k of these errors are actually user-facing (probably not!), but in any case, this is a problem. 

I don't know this for certain, but I _assume_ the issue here is that there's lazy loading for the single signon object, and we aren't correctly getting it to load. However, I don't really want to investigate this further (both wasting time and also risking breaking something else by making changes where I don't really understand 100% what's going on). We _don't_ see this issue for the sign up tracking event or identify event, so I'd like to remove this property from all the events except the signup & identify events. We can join on the appropriate tables to get the DQ user id. [See also slack thread](https://dataquest.slack.com/archives/CPTS0ES1Z/p1601374655034500) -- I'll wait for Josh & Success team's response before moving forward with this approach.

Fixes https://www.pivotaltracker.com/story/show/175034101